### PR TITLE
Changed Coverage Provider To Babel From v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "jest": {
     "coverageDirectory": "coverage",
-    "coverageProvider": "v8",
     "coverageReporters": [
       "lcov"
     ],


### PR DESCRIPTION
# WHAT'S NEW
Changed coverage provider from v8 to babel
# WHY
The V8 provider is still experimental and it have some bags that effects coverage 