### PR TITLE
Added API to control WordPress users 

### DIFF
--- a/src/wp-cli/types.js
+++ b/src/wp-cli/types.js
@@ -53,3 +53,18 @@
  * @property {string} description - The plugin description.
  * @property {string} file - plugin file path from parent plugin directory.
  */
+
+/**
+ * @typedef UserGetObject
+ * @property {string} ID - User id.
+ * @property {string} user_login - User login name
+ * @property {string} display_name - User display name
+ * @property {string} user_email - User email
+ * @property {string} user_registered - User registration date
+ * @property {string} roles - User roles.
+ * @property {string} user_pass - Hashed user password
+ * @property {string} user_nicename - User nickname.
+ * @property {string} user_url - user url
+ * @property {string} user_activation_key - User activation key
+ * @property {string} user_status - The user status (no real use)
+ */

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -16,7 +16,7 @@ class UserMeta {
   /**
    * Adds a meta field.
    *
-   * @param {string} user - The user login, user email, or user ID of the user to add metadata for.
+   * @param {string|number} user - The user login, user email, or user ID of the user to add metadata for.
    * @param {string} key - The metadata key.
    * @param {string} value - The new metadata value.
    * @returns {Promise<RunInContainerOutput>} The command output.
@@ -30,7 +30,7 @@ class UserMeta {
   /**
    * Deletes a meta field.
    *
-   * @param {string} user - The user login, user email, or user ID of the user to delete metadata from.
+   * @param {string|number} user - The user login, user email, or user ID of the user to delete metadata from.
    * @param {string} key - he metadata key.
    * @returns {Promise<RunInContainerOutput>} The command output.
    */
@@ -43,7 +43,7 @@ class UserMeta {
   /**
    * Gets meta field value.
    *
-   * @param {string} user - The user login, user email, or user ID of the user to get metadata for.
+   * @param {string|number} user - The user login, user email, or user ID of the user to get metadata for.
    * @param {string} key - The metadata key.
    * @returns {Promise<any>} The command output.
    */
@@ -57,7 +57,7 @@ class UserMeta {
   /**
    * Lists all metadata associated with a user.
    *
-   * @param {string} user - The user login, user email, or user ID of the user to get metadata for.
+   * @param {string|number} user - The user login, user email, or user ID of the user to get metadata for.
    * @returns {Promise<{user_id: number, meta_key: string, meta_value: string}>} list of the user metadata
    */
   list (user) {
@@ -131,7 +131,7 @@ class User {
   /**
    * Creates a new user.
    *
-   * @param {object} options - Option to create new user.
+   * @param {object} options - Options to create new user.
    * @param {string} options.userLogin - The login of the user to create.
    * @param {string} options.userPass - The user password.
    * @param {'administrator'|'editor'|'author'|'contributor'|'subscriber'} options.role - The role of the user to create. Default: default role. Possible values include ‘administrator’, ‘editor’, ‘author’, ‘contributor’, ‘subscriber’.
@@ -150,7 +150,7 @@ class User {
     const createArgs = ['add-role', '--porcelain']
 
     if (!options.userLogin) {
-      throw new TypeError('option.userLogin must be provided!')
+      throw new TypeError('options.userLogin must be provided!')
     }
 
     createArgs.push(options.userLogin)
@@ -162,7 +162,7 @@ class User {
     createArgs.push(options.userEmail)
 
     if (!options.userPass) {
-      throw new TypeError('option.userPass must be provided!')
+      throw new TypeError('options.userPass must be provided!')
     }
 
     createArgs.push(`--user_pass=${options.userPass}`)
@@ -213,12 +213,12 @@ class User {
   /**
    * Deletes one or more users from the current site.
    *
-   * @param {string} user - The user login, user email, or user ID of the user(s) to delete.
+   * @param {string|number} user - The user login, user email, or user ID of the user(s) to delete.
    * @param {number} [reassign] -  User ID to reassign the posts to.
    * @returns {Promise<RunInContainerOutput>} The output of the command.
    */
   delete (user, reassign) {
-    user = CheckIfArrayOrString(user)
+    user = CheckIfArrayOrString(user, 'user')
 
     const deleteArgs = ['delete', '--yes']
 
@@ -234,7 +234,7 @@ class User {
   /**
    * Get user data.
    *
-   * @param {string} user - The user to get.
+   * @param {string|number} user - The user to get.
    * @returns {Promise<UserGetObject>} Current user data.
    */
   get (user) {
@@ -277,7 +277,7 @@ class User {
   /**
    * Return the user's capabilities
    *
-   * @param {string} user - User to check
+   * @param {string|number} user - User to check
    * @returns {Promise<{name: string}[]>} List of the user capabilities.
    */
   listCaps (user) {
@@ -285,6 +285,77 @@ class User {
 
     return this.wpUser(listCapsArgs)
       .then(output => JSON.parse(output.stdout))
+  }
+
+  /**
+   * Removes a user's capability.
+   *
+   * @param {string|number} user - User ID, user email, or user login.
+   * @param {string} cap - The capability to be removed.
+   * @returns {Promise<RunInContainerOutput>} The output of the command.
+   */
+  removeCap (user, cap) {
+    const removeCapArgs = ['remove-cap', user, cap]
+
+    return this.wpUser(removeCapArgs)
+  }
+
+  /**
+   * Removes a user's role.
+   *
+   * @param {string|number} user - User ID, user email, or user login.
+   * @param {string} cap - A specific role to remove.
+   * @returns {Promise<RunInContainerOutput>} The output of the command.
+   */
+  removeRole (user, cap) {
+    const removeRoleArgs = ['remove-role', user, cap]
+
+    return this.wpUser(removeRoleArgs)
+  }
+
+  /**
+   * Sets the user role.
+   *
+   * @param {string} user - User ID, user email, or user login.
+   * @param {string} role - Make the user have the specified role. If not passed, the default role is used.
+   * @returns {Promise<RunInContainerOutput>} The output of the command.
+   */
+  setRole (user, role) {
+    const setRoleArgs = ['set-role', user, role]
+
+    return this.wpUser(setRoleArgs)
+  }
+
+  /**
+   * Marks one or more users as spam.
+   *
+   * @param {string|number|number[]|string[]} user - One or more id's of users to mark as spam.
+   * @returns {Promise<RunInContainerOutput>} The command output
+   */
+  spam (user) {
+    user = CheckIfArrayOrString(user, 'user')
+
+    const spamArgs = ['spam']
+
+    spamArgs.push.apply(user)
+
+    return this.wpUser(spamArgs)
+  }
+
+  /**
+   * Removes one or more users from spam.
+   *
+   * @param {string|number|number[]|string[]} user - One or more IDs of users to remove from spam.
+   * @returns {Promise<RunInContainerOutput>} The command output
+   */
+  unspam (user) { // eslint-disable-line spellcheck/spell-checker
+    user = CheckIfArrayOrString(user, 'user')
+
+    const args = ['unspam'] // eslint-disable-line spellcheck/spell-checker
+
+    args.push.apply(user)
+
+    return this.wpUser(args)
   }
 }
 

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -357,6 +357,48 @@ class User {
 
     return this.wpUser(args)
   }
+
+  /**
+   * Updates an existing user.
+   *
+   * @param {object} options - Options to update user.
+   * @param {string|number|string[]|number[]} options.user - The user login, user email or user ID of the user(s) to update.
+   * @param {string} [options.userPass] - A string that contains the plain text password for the user.
+   * @param {string} [options.userNicename] - A string that contains a URL-friendly name for the user. The default is the user’s username.
+   * @param {string} [options.userUrl] - A string containing the user’s URL for the user’s web site.
+   * @param {string} [options.userEmail] - A string containing the user’s email address.
+   * @param {string} [options.displayName] - A string that will be shown on the site. Defaults to user’s username.
+   * @param {string} [options.nickname] - The user’s nickname, defaults to the user’s username.
+   * @param {string} [options.firstName] - The user’s first name.
+   * @param {string} [options.lastName] - The user’s last name.
+   * @param {string} [options.description] -A string containing content about the user.
+   * @param {string} [options.userRegistered] - The date the user registered.
+   * @param {string} [options.role] - A string used to set the user’s role.
+   * @returns {Promise<RunInContainerOutput>} the output of the command.
+   */
+  update (options) {
+    const updateArgs = ['update', '--skip-email']
+
+    if (!options.user) {
+      throw new TypeError('options.user must be provided')
+    }
+
+    options.user = CheckIfArrayOrString(options.user, 'options.user')
+
+    if (options.description) { updateArgs.push(`--description=${options.description}`) }
+    if (options.displayName) { updateArgs.push(`--display_name=${options.displayName}`) }
+    if (options.firstName) { updateArgs.push(`--first_name=${options.firstName}`) }
+    if (options.lastName) { updateArgs.push(`--last_name=${options.lastName}`) }
+    if (options.nickname) { updateArgs.push(`--nickname=${options.nickname}`) }
+    if (options.role) { updateArgs.push(`--role=${options.role}`) }
+    if (options.userEmail) { updateArgs.push(`--role=${options.userEmail}`) }
+    if (options.userNicename) { updateArgs.push(`--user_nicename=${options.userNicename}`) }
+    if (options.userPass) { updateArgs.push(`--user_pass=${options.userPass}`) }
+    if (options.userRegistered) { updateArgs.push(`--user_registered=${options.userRegistered}`) }
+    if (options.userUrl) { updateArgs.push(`--user_url=${options.userUrl}`) }
+
+    return this.wpUser(updateArgs)
+  }
 }
 
 module.exports = User

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -2,6 +2,9 @@ require('./types')
 const { CreateWordpressCliContainer } = require('../docker/presets/containers')
 const { FormatToWordpressDate, CheckIfArrayOrString } = require('./util')
 
+/**
+ * Adds, updates, deletes, and lists user custom fields.
+ */
 class UserMeta {
   /**
    * Constructor for the UserMeta object.
@@ -79,6 +82,9 @@ class UserMeta {
   }
 }
 
+/**
+ * Manages users, along with their roles, capabilities, and meta.
+ */
 class User {
   /**
    * Constructor for the User object.

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -323,7 +323,7 @@ class User {
 
     const spamArgs = ['spam']
 
-    spamArgs.push.apply(user)
+    spamArgs.push.apply(spamArgs, user)
 
     return this.wpUser(spamArgs)
   }

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -343,7 +343,7 @@ class User {
 
     const args = ['unspam'] // eslint-disable-line spellcheck/spell-checker
 
-    args.push.apply(user)
+    args.push.apply(args, user)
 
     return this.wpUser(args)
   }

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -153,14 +153,22 @@ class User {
     return this.wpUser(deleteArgs)
   }
 
-  get () {
+  /**
+   * Get user data.
+   *
+   * @param {string} user - The user to get.
+   * @returns {Promise<UserGetObject>} Current user data.
+   */
+  get (user) {
     const getArgs = [
       'get',
       '--format=json',
       '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status',
+      user,
     ]
 
     return this.wpUser(getArgs)
+      .then(output => JSON.parse(output.stdout))
   }
 }
 

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -134,7 +134,7 @@ class User {
    * @param {object} options - Options to create new user.
    * @param {string} options.userLogin - The login of the user to create.
    * @param {string} options.userPass - The user password.
-   * @param {'administrator'|'editor'|'author'|'contributor'|'subscriber'} options.role - The role of the user to create. Default: default role. Possible values include ‘administrator’, ‘editor’, ‘author’, ‘contributor’, ‘subscriber’.
+   * @param {'administrator'|'editor'|'author'|'contributor'|'subscriber'} [options.role] - The role of the user to create. Default: default role. Possible values include ‘administrator’, ‘editor’, ‘author’, ‘contributor’, ‘subscriber’.
    * @param {Date} [options.userRegistered] - The date the user registered. Default: current date.
    * @param {string} [options.displayName] - The display name.
    * @param {string} [options.userNicename] - A string that contains a URL-friendly name for the user. The default is the user’s username.
@@ -147,8 +147,8 @@ class User {
    *
    * @returns {Promise<RunInContainerOutput>} Retruns newy created User id.
    */
-  create (options) {
-    const createArgs = ['add-role', '--porcelain']
+  create (options = {}) {
+    const createArgs = ['create', '--porcelain']
 
     if (!options.userLogin) {
       throw new TypeError('options.userLogin must be provided!')
@@ -234,7 +234,7 @@ class User {
    * @param {UserGetObject} [filters] - Filter results based on the value of a field.
    * @returns {Promise<UserGetObject[]>} - List of users in the wordpress site.
    */
-  list (filters) {
+  list (filters = {}) {
     const listArgs = [
       'list',
       '--format=json',
@@ -352,11 +352,11 @@ class User {
    * @param {string} [options.lastName] - The user’s last name.
    * @param {string} [options.description] -A string containing content about the user.
    * @param {Date} [options.userRegistered] - The date the user registered.
-   * @param {string} [options.role] - A string used to set the user’s role.
+   * @param {'administrator'|'editor'|'author'|'contributor'|'subscriber'} [options.role] - A string used to set the user’s role.
    *
    * @returns {Promise<RunInContainerOutput>} the output of the command.
    */
-  update (options) {
+  update (options = {}) {
     const updateArgs = ['update', '--skip-email']
 
     if (!options.user) {

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -71,6 +71,8 @@ class UserMeta {
   }
 
   /**
+   * Updates a meta field.
+   *
    * @param {string|number} user - The user login, user email, or user ID of the user to update metadata for.
    * @param {string} key - The metadata key.
    * @param {string} value - The new metadata value.

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -168,8 +168,6 @@ class User {
 
     createArgs.push(`--user_pass=${options.userPass}`)
 
-    if (options.role) { createArgs.push(`--role=${options.role}`) }
-
     if (options.userRegistered) {
       if (!(options.userRegistered instanceof Date)) {
         throw new TypeError('options.userRegistered must be instance of Date!')
@@ -178,6 +176,7 @@ class User {
       createArgs.push(`--user_registered=${FormatToWordpressDate(options.userRegistered)}`)
     }
 
+    if (options.role) { createArgs.push(`--role=${options.role}`) }
     if (options.displayName) { createArgs.push(`--display_name=${options.displayName}`) }
     if (options.userNicename) { createArgs.push(`--user_nicename=${options.userNicename}`) }
     if (options.userUrl) { createArgs.push(`--user_url=${options.userUrl}`) }

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -119,11 +119,11 @@ class User {
    * Adds a role for a user.
    *
    * @param {number|string} user - User ID, user email, or user login.
-   * @param {string} cap - Add the specified role to the user.
+   * @param {string} role - Add the specified role to the user.
    * @returns {Promise<RunInContainerOutput>} The output of the command.
    */
-  addRole (user, cap) {
-    const addRoleArgs = ['add-role', user, cap]
+  addRole (user, role) {
+    const addRoleArgs = ['add-role', user, role]
 
     return this.wpUser(addRoleArgs)
   }

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -144,6 +144,7 @@ class User {
    * @param {string} [options.lastName] - The user’s last name.
    * @param {string} [options.description] - A string containing content about the user.
    * @param {string} [options.userEmail] - The email address of the user to create. default: `${options.userLogin}@cywp.local`
+   *
    * @returns {Promise<RunInContainerOutput>} Retruns newy created User id.
    */
   create (options) {
@@ -167,9 +168,7 @@ class User {
 
     createArgs.push(`--user_pass=${options.userPass}`)
 
-    if (options.role) {
-      createArgs.push(`--role=${options.role}`)
-    }
+    if (options.role) { createArgs.push(`--role=${options.role}`) }
 
     if (options.userRegistered) {
       if (!(options.userRegistered instanceof Date)) {
@@ -179,33 +178,13 @@ class User {
       createArgs.push(`--user_registered=${FormatToWordpressDate(options.userRegistered)}`)
     }
 
-    if (options.displayName) {
-      createArgs.push(`--display_name=${options.displayName}`)
-    }
-
-    if (options.userNicename) {
-      createArgs.push(`--user_nicename=${options.userNicename}`)
-    }
-
-    if (options.userUrl) {
-      createArgs.push(`--user_url=${options.userUrl}`)
-    }
-
-    if (options.nickname) {
-      createArgs.push(`--nickname=${options.nickname}`)
-    }
-
-    if (options.firstName) {
-      createArgs.push(`--first_name=${options.firstName}`)
-    }
-
-    if (options.lastName) {
-      createArgs.push(`--last_name=${options.lastName}`)
-    }
-
-    if (options.description) {
-      createArgs.push(`--description=${options.description}`)
-    }
+    if (options.displayName) { createArgs.push(`--display_name=${options.displayName}`) }
+    if (options.userNicename) { createArgs.push(`--user_nicename=${options.userNicename}`) }
+    if (options.userUrl) { createArgs.push(`--user_url=${options.userUrl}`) }
+    if (options.nickname) { createArgs.push(`--nickname=${options.nickname}`) }
+    if (options.firstName) { createArgs.push(`--first_name=${options.firstName}`) }
+    if (options.lastName) { createArgs.push(`--last_name=${options.lastName}`) }
+    if (options.description) { createArgs.push(`--description=${options.description}`) }
 
     return this.wpUser(createArgs)
   }
@@ -372,8 +351,9 @@ class User {
    * @param {string} [options.firstName] - The user’s first name.
    * @param {string} [options.lastName] - The user’s last name.
    * @param {string} [options.description] -A string containing content about the user.
-   * @param {string} [options.userRegistered] - The date the user registered.
+   * @param {Date} [options.userRegistered] - The date the user registered.
    * @param {string} [options.role] - A string used to set the user’s role.
+   *
    * @returns {Promise<RunInContainerOutput>} the output of the command.
    */
   update (options) {
@@ -385,6 +365,16 @@ class User {
 
     options.user = CheckIfArrayOrString(options.user, 'options.user')
 
+    updateArgs.push.apply(updateArgs, options.user)
+
+    if (options.userRegistered) {
+      if (!(options.userRegistered instanceof Date)) {
+        throw new TypeError('options.userRegistered must be instance of Date!')
+      }
+
+      updateArgs.push(`--user_registered=${FormatToWordpressDate(options.userRegistered)}`)
+    }
+
     if (options.description) { updateArgs.push(`--description=${options.description}`) }
     if (options.displayName) { updateArgs.push(`--display_name=${options.displayName}`) }
     if (options.firstName) { updateArgs.push(`--first_name=${options.firstName}`) }
@@ -394,7 +384,6 @@ class User {
     if (options.userEmail) { updateArgs.push(`--role=${options.userEmail}`) }
     if (options.userNicename) { updateArgs.push(`--user_nicename=${options.userNicename}`) }
     if (options.userPass) { updateArgs.push(`--user_pass=${options.userPass}`) }
-    if (options.userRegistered) { updateArgs.push(`--user_registered=${options.userRegistered}`) }
     if (options.userUrl) { updateArgs.push(`--user_url=${options.userUrl}`) }
 
     return this.wpUser(updateArgs)

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -2,6 +2,83 @@ require('./types')
 const { CreateWordpressCliContainer } = require('../docker/presets/containers')
 const { FormatToWordpressDate, CheckIfArrayOrString } = require('./util')
 
+class UserMeta {
+  /**
+   * Constructor for the UserMeta object.
+   *
+   * @param {(commands: string) => Promise<RunInContainerOutput>} wpUser - the wpUser user command.
+   */
+  constructor (wpUser) {
+    /** @type {(commands: string) => Promise<RunInContainerOutput>} */
+    this.wpUserMeta = (commands) => wpUser(commands.concat('meta'))
+  }
+
+  /**
+   * Adds a meta field.
+   *
+   * @param {string} user - The user login, user email, or user ID of the user to add metadata for.
+   * @param {string} key - The metadata key.
+   * @param {string} value - The new metadata value.
+   * @returns {Promise<RunInContainerOutput>} The command output.
+   */
+  add (user, key, value) {
+    const addArgs = ['add', user, key, value]
+
+    return this.wpUserMeta(addArgs)
+  }
+
+  /**
+   * Deletes a meta field.
+   *
+   * @param {string} user - The user login, user email, or user ID of the user to delete metadata from.
+   * @param {string} key - he metadata key.
+   * @returns {Promise<RunInContainerOutput>} The command output.
+   */
+  delete (user, key) {
+    const deleteArgs = ['delete', user, key]
+
+    return this.wpUserMeta(deleteArgs)
+  }
+
+  /**
+   * Gets meta field value.
+   *
+   * @param {string} user - The user login, user email, or user ID of the user to get metadata for.
+   * @param {string} key - The metadata key.
+   * @returns {Promise<any>} The command output.
+   */
+  get (user, key) {
+    const getArgs = ['get', '--format=json', user, key]
+
+    return this.wpUserMeta(getArgs)
+      .then(output => JSON.parse(output.stdout))
+  }
+
+  /**
+   * Lists all metadata associated with a user.
+   *
+   * @param {string} user - The user login, user email, or user ID of the user to get metadata for.
+   * @returns {Promise<{user_id: number, meta_key: string, meta_value: string}>} list of the user metadata
+   */
+  list (user) {
+    const listArgs = ['list', '--format=json', user]
+
+    return this.wpUserMeta(listArgs)
+      .then(output => JSON.parse(output))
+  }
+
+  /**
+   * @param {string|number} user - The user login, user email, or user ID of the user to update metadata for.
+   * @param {string} key - The metadata key.
+   * @param {string} value - The new metadata value.
+   */
+  update (user, key, value) {
+    const updateArgs = ['update', user, key, value]
+
+    this.wpUserMeta(updateArgs)
+  }
+}
+
 class User {
   /**
    * Constructor for the User object.
@@ -10,6 +87,7 @@ class User {
    */
   constructor (site) {
     this.site = site
+    this.Meta = new UserMeta(this.wpUser)
   }
 
   /**

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -181,7 +181,7 @@ class User {
     const listArgs = [
       'list',
       '--format=json',
-      '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status', // eslint-disable-line spellcheck/spell-checker
+      '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status',
     ]
 
     if ('object' !== typeof filters) {

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -196,6 +196,10 @@ class User {
    * @returns {Promise<RunInContainerOutput>} The output of the command.
    */
   delete (user, reassign) {
+    if ('number' === typeof user) {
+      user = user.toString()
+    }
+
     user = CheckIfArrayOrString(user, 'user')
 
     const deleteArgs = ['delete', '--yes']
@@ -311,6 +315,10 @@ class User {
    * @returns {Promise<RunInContainerOutput>} The command output
    */
   spam (user) {
+    if ('number' === typeof user) {
+      user = user.toString()
+    }
+
     user = CheckIfArrayOrString(user, 'user')
 
     const spamArgs = ['spam']
@@ -327,6 +335,10 @@ class User {
    * @returns {Promise<RunInContainerOutput>} The command output
    */
   unspam (user) { // eslint-disable-line spellcheck/spell-checker
+    if ('number' === typeof user) {
+      user = user.toString()
+    }
+
     user = CheckIfArrayOrString(user, 'user')
 
     const args = ['unspam'] // eslint-disable-line spellcheck/spell-checker
@@ -360,6 +372,10 @@ class User {
 
     if (!options.user) {
       throw new TypeError('options.user must be provided')
+    }
+
+    if ('number' === typeof options.user) {
+      options.user = options.user.toString()
     }
 
     options.user = CheckIfArrayOrString(options.user, 'options.user')

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -334,14 +334,14 @@ class User {
    * @param {string|number|number[]|string[]} user - One or more IDs of users to remove from spam.
    * @returns {Promise<RunInContainerOutput>} The command output
    */
-  unspam (user) { // eslint-disable-line spellcheck/spell-checker
+  unspam (user) {
     if ('number' === typeof user) {
       user = user.toString()
     }
 
     user = CheckIfArrayOrString(user, 'user')
 
-    const args = ['unspam'] // eslint-disable-line spellcheck/spell-checker
+    const args = ['unspam']
 
     args.push.apply(args, user)
 

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -6,11 +6,11 @@ class UserMeta {
   /**
    * Constructor for the UserMeta object.
    *
-   * @param {(commands: string) => Promise<RunInContainerOutput>} wpUser - the wpUser user command.
+   * @param {User} user - the user object.
    */
-  constructor (wpUser) {
-    /** @type {(commands: string) => Promise<RunInContainerOutput>} */
-    this.wpUserMeta = (commands) => wpUser(commands.concat('meta'))
+  constructor (user) {
+    /** @type {(commands: string[]) => Promise<RunInContainerOutput>} */
+    this.wpUserMeta = (commands) => user.wpUser(['meta', ...commands])
   }
 
   /**
@@ -64,7 +64,7 @@ class UserMeta {
     const listArgs = ['list', '--format=json', user]
 
     return this.wpUserMeta(listArgs)
-      .then(output => JSON.parse(output))
+      .then(output => JSON.parse(output.stdout))
   }
 
   /**
@@ -87,7 +87,7 @@ class User {
    */
   constructor (site) {
     this.site = site
-    this.Meta = new UserMeta(this.wpUser)
+    this.Meta = new UserMeta(this)
   }
 
   /**
@@ -396,7 +396,7 @@ class User {
     if (options.lastName) { updateArgs.push(`--last_name=${options.lastName}`) }
     if (options.nickname) { updateArgs.push(`--nickname=${options.nickname}`) }
     if (options.role) { updateArgs.push(`--role=${options.role}`) }
-    if (options.userEmail) { updateArgs.push(`--role=${options.userEmail}`) }
+    if (options.userEmail) { updateArgs.push(`--user_email=${options.userEmail}`) }
     if (options.userNicename) { updateArgs.push(`--user_nicename=${options.userNicename}`) }
     if (options.userPass) { updateArgs.push(`--user_pass=${options.userPass}`) }
     if (options.userUrl) { updateArgs.push(`--user_url=${options.userUrl}`) }

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -1,7 +1,6 @@
 require('./types')
 const { CreateWordpressCliContainer } = require('../docker/presets/containers')
-const { FormatToWordpressDate } = require('./util')
-// const { CheckIfArrayOrString } = require('./util')
+const { FormatToWordpressDate, CheckIfArrayOrString } = require('./util')
 
 class User {
   /**
@@ -106,8 +105,8 @@ class User {
       createArgs.push(`--display_name=${options.displayName}`)
     }
 
-    if (options.userNicename) { // eslint-disable-line spellcheck/spell-checker
-      createArgs.push(`--user_nicename=${options.userNicename}`) // eslint-disable-line spellcheck/spell-checker
+    if (options.userNicename) {
+      createArgs.push(`--user_nicename=${options.userNicename}`)
     }
 
     if (options.userUrl) {
@@ -131,6 +130,37 @@ class User {
     }
 
     return this.wpUser(createArgs)
+  }
+
+  /**
+   * Deletes one or more users from the current site.
+   *
+   * @param {string} user - The user login, user email, or user ID of the user(s) to delete.
+   * @param {number} [reassign] -  User ID to reassign the posts to.
+   * @returns {Promise<RunInContainerOutput>} The output of the command.
+   */
+  delete (user, reassign) {
+    user = CheckIfArrayOrString(user)
+
+    const deleteArgs = ['delete', '--yes']
+
+    if (reassign) {
+      deleteArgs.push(`--reassign=${reassign}`)
+    }
+
+    deleteArgs.push.apply(deleteArgs, user)
+
+    return this.wpUser(deleteArgs)
+  }
+
+  get () {
+    const getArgs = [
+      'get',
+      '--format=json',
+      '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status',
+    ]
+
+    return this.wpUser(getArgs)
   }
 }
 

--- a/src/wp-cli/user.js
+++ b/src/wp-cli/user.js
@@ -170,6 +170,44 @@ class User {
     return this.wpUser(getArgs)
       .then(output => JSON.parse(output.stdout))
   }
+
+  /**
+   * Return list of users in the wordpress site and there data.
+   *
+   * @param {UserGetObject} [filters] - Filter results based on the value of a field.
+   * @returns {Promise<UserGetObject[]>} - List of users in the wordpress site.
+   */
+  list (filters) {
+    const listArgs = [
+      'list',
+      '--format=json',
+      '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status', // eslint-disable-line spellcheck/spell-checker
+    ]
+
+    if ('object' !== typeof filters) {
+      throw new TypeError('filters must be an object')
+    }
+
+    for (const filtersField in filters) {
+      listArgs.push(`--${filtersField}=${filters[filtersField]}`)
+    }
+
+    return this.wpUser(listArgs)
+      .then(output => JSON.parse(output.stdout))
+  }
+
+  /**
+   * Return the user's capabilities
+   *
+   * @param {string} user - User to check
+   * @returns {Promise<{name: string}[]>} List of the user capabilities.
+   */
+  listCaps (user) {
+    const listCapsArgs = ['list-caps', '--format=json', user]
+
+    return this.wpUser(listCapsArgs)
+      .then(output => JSON.parse(output.stdout))
+  }
 }
 
 module.exports = User

--- a/src/wp-cli/util.js
+++ b/src/wp-cli/util.js
@@ -18,4 +18,23 @@ function CheckIfArrayOrString (item, purpose) {
   return item
 }
 
-module.exports = { CheckIfArrayOrString }
+/**
+ * Format the date to yyyy-mm-dd-hh-ii-ss style.
+ *
+ * @param {Date} date - the date to format.
+ * @returns {string} formatted string.
+ */
+function FormatToWordpressDate (date) {
+  const twoDigits = (number) => 10 > number ? '0' + number : number
+
+  return [
+    date.getFullYear(),
+    twoDigits(date.getMonth()),
+    twoDigits(date.getDate()),
+    twoDigits(date.getHours()),
+    twoDigits(date.getMinutes()),
+    twoDigits(date.getSeconds()),
+  ].join('-')
+}
+
+module.exports = { CheckIfArrayOrString, FormatToWordpressDate }

--- a/src/wp-cli/util.js
+++ b/src/wp-cli/util.js
@@ -29,7 +29,7 @@ function FormatToWordpressDate (date) {
 
   return [
     date.getFullYear(),
-    twoDigits(date.getMonth()),
+    twoDigits(date.getMonth() + 1),
     twoDigits(date.getDate()),
     twoDigits(date.getHours()),
     twoDigits(date.getMinutes()),

--- a/test/wp-cli/user.spec.js
+++ b/test/wp-cli/user.spec.js
@@ -421,4 +421,165 @@ describe('User', () => {
         .toHaveBeenLastCalledWith(['unspam', 'user', 1])
     })
   })
+
+  describe('#update()', () => {
+    it('should throw error when user id in not given', () => {
+      expect(() => user.update({})).toThrow(new TypeError('options.user must be provided'))
+
+      expect(() => user.update()).toThrow(new TypeError('options.user must be provided'))
+    })
+
+    it('should throw error when user Registered date is not date object', () => {
+      expect(() => user.update({ user: 'user', userRegistered: 'error' })).toThrow(new TypeError('options.userRegistered must be instance of Date!'))
+    })
+
+    it('should have the arguments to update user', () => {
+      user.update({ user: 'user' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user'])
+    })
+
+    it('should have the arguments to update user with user id as parameter', () => {
+      user.update({ user: 1 })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', '1'])
+    })
+
+    it('should have the arguments to update multiple users', () => {
+      user.update({ user: ['user', 1] })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', 1])
+    })
+
+    it('should have the arguments to update user description', () => {
+      user.update({ user: 'user', description: 'user-description' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--description=user-description'])
+    })
+
+    it('should have the arguments to update user registered date', () => {
+      user.update({ user: 'user', userRegistered: new Date(2020, 10, 10) })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--user_registered=2020-11-10-00-00-00'])
+    })
+
+    it('should have the arguments to update user display name', () => {
+      user.update({ user: 'user', displayName: 'user-display-name' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--display_name=user-display-name'])
+    })
+
+    it('should have the arguments to update user first name', () => {
+      user.update({ user: 'user', firstName: 'user-first-name' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--first_name=user-first-name'])
+    })
+
+    it('should have the arguments to update user last name', () => {
+      user.update({ user: 'user', lastName: 'user-last-name' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--last_name=user-last-name'])
+    })
+
+    it('should have the arguments to update user nickname', () => {
+      user.update({ user: 'user', nickname: 'user-nickname' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--nickname=user-nickname'])
+    })
+
+    it('should have the arguments to update user role', () => {
+      user.update({ user: 'user', role: 'user-role' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--role=user-role'])
+    })
+
+    it('should have the arguments to update user email', () => {
+      user.update({ user: 'user', userEmail: 'user-email' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--user_email=user-email'])
+    })
+
+    it('should have the arguments to update user nicename', () => {
+      user.update({ user: 'user', userNicename: 'user-nicename' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--user_nicename=user-nicename'])
+    })
+
+    it('should have the arguments to update user password', () => {
+      user.update({ user: 'user', userPass: 'user-password' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--user_pass=user-password'])
+    })
+
+    it('should have the arguments to update user url', () => {
+      user.update({ user: 'user', userUrl: 'user-url' })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['update', '--skip-email', 'user', '--user_url=user-url'])
+    })
+  })
+
+  describe('#UserMeta', () => {
+    describe('##add()', () => {
+      it('should have arguments to add user metadata', () => {
+        user.Meta.add(1, 'add-metadata-key', 'add-metadata-value')
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith(['meta', 'add', 1, 'add-metadata-key', 'add-metadata-value'])
+      })
+    })
+
+    describe('##delete()', () => {
+      it('should have arguments to delete user metadata', () => {
+        user.Meta.delete(1, 'delete-metadata-key')
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith(['meta', 'delete', 1, 'delete-metadata-key'])
+      })
+    })
+
+    describe('##get()', () => {
+      it('should have arguments to get user metadata', () => {
+        user.wpUser = jest.fn((commands) => Promise.resolve({ stdout: JSON.stringify(commands) }))
+
+        user.Meta.get(1, 'get-metadata-key')
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith(['meta', 'get', '--format=json', 1, 'get-metadata-key'])
+      })
+    })
+
+    describe('##list()', () => {
+      it('should have arguments to list user metadata', () => {
+        user.wpUser = jest.fn((commands) => Promise.resolve({ stdout: JSON.stringify(commands) }))
+
+        user.Meta.list(1)
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith(['meta', 'list', '--format=json', 1])
+      })
+    })
+
+    describe('##update()', () => {
+      it('should have arguments to update user metadata', () => {
+        user.Meta.update(1, 'update-metadata-key', 'update-metadata-value')
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith(['meta', 'update', 1, 'update-metadata-key', 'update-metadata-value'])
+      })
+    })
+  })
 })

--- a/test/wp-cli/user.spec.js
+++ b/test/wp-cli/user.spec.js
@@ -1,0 +1,424 @@
+const { CreateWordpressCliContainer } = require('../../src/docker/presets/containers')
+const User = require('../../src/wp-cli/user')
+
+jest.mock('../../src/docker/presets/containers')
+
+describe('User', () => {
+  /** @type {User} */
+  let user
+  let originalWpUser
+
+  beforeAll(() => {
+    user = new User()
+    originalWpUser = user.wpUser
+  })
+
+  beforeEach(async () => {
+    user.wpUser = jest.fn()
+  })
+
+  describe('#wpUser()', () => {
+    beforeEach(() => {
+      user.wpUser = originalWpUser
+    })
+
+    it('should have the arguments wp plugin', () => {
+      user.wpUser([])
+
+      expect(CreateWordpressCliContainer)
+        .toHaveBeenLastCalledWith(undefined, ['wp', 'user'])
+    })
+  })
+
+  describe('#addCap()', () => {
+    it('should have the arguments to add cap', () => {
+      user.addCap(1, 'cap')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['add-cap', 1, 'cap'])
+    })
+  })
+
+  describe('#addRole()', () => {
+    it('should have the arguments to add role', () => {
+      user.addRole(1, 'role')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['add-role', 1, 'role'])
+    })
+  })
+
+  describe('#create()', () => {
+    describe('##throws', () => {
+      it('should throw error if user name not provided', () => {
+        expect(() => user.create()).toThrow('options.userLogin must be provided!')
+
+        expect(() => user.create({})).toThrow('options.userLogin must be provided!')
+      })
+
+      it('should throw error if password not provided', () => {
+        expect(() => user.create({ userLogin: 'cywp' })).toThrow('options.userPass must be provided!')
+      })
+
+      it('should throw error if userRegistered is not a valid date', () => {
+        expect(() => user.create({ userLogin: 'cywp', userPass: 'cywp', userRegistered: '2020.12.15' })).toThrow('options.userRegistered must be instance of Date!')
+      })
+    })
+
+    describe('##returns', () => {
+      it('should have the arguments to create basic user', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+          ])
+      })
+
+      it('should have the arguments to create user with custom email', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          userEmail: 'pop@pop.com',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'pop@pop.com',
+            '--user_pass=cywp-password',
+          ])
+      })
+
+      it('should have the arguments to create user with custom display name', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          displayName: 'cywp-display-name',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--display_name=cywp-display-name',
+          ])
+      })
+
+      it('should have the arguments to create user with custom nicename', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          userNicename: 'cywp-nicename',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--user_nicename=cywp-nicename',
+          ])
+      })
+
+      it('should have the arguments to create user with custom user url', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          userUrl: 'cywp-user-url',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--user_url=cywp-user-url',
+          ])
+      })
+
+      it('should have the arguments to create user with custom nickname', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          nickname: 'cywp-nickname',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--nickname=cywp-nickname',
+          ])
+      })
+
+      it('should have the arguments to create user with custom first name', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          firstName: 'cywp-first-name',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--first_name=cywp-first-name',
+          ])
+      })
+
+      it('should have the arguments to create user with custom last name', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          lastName: 'cywp-last-name',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--last_name=cywp-last-name',
+          ])
+      })
+
+      it('should have the arguments to create user with custom description', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          description: 'cywp-description',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--description=cywp-description',
+          ])
+      })
+
+      it('should have the arguments to create user with custom role', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          role: 'cywp-role',
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--role=cywp-role',
+          ])
+      })
+
+      it('should have the arguments to create user with custom registered date', () => {
+        user.create({
+          userLogin: 'cywp-user',
+          userPass: 'cywp-password',
+          userRegistered: new Date(2020, 10, 10),
+        })
+
+        expect(user.wpUser)
+          .toHaveBeenLastCalledWith([
+            'create',
+            '--porcelain',
+            'cywp-user',
+            'cywp-user@cywp.local',
+            '--user_pass=cywp-password',
+            '--user_registered=2020-11-10-00-00-00',
+          ])
+      })
+    })
+  })
+
+  describe('#delete()', () => {
+    it('should have the arguments to delete user', () => {
+      user.delete(1)
+
+      expect(user.wpUser).toHaveBeenLastCalledWith(['delete', '--yes', '1'])
+
+      user.delete('user')
+
+      expect(user.wpUser).toHaveBeenLastCalledWith(['delete', '--yes', 'user'])
+    })
+
+    it('should have the arguments to delete user and reassign posts', () => {
+      user.delete(1, 12)
+
+      expect(user.wpUser).toHaveBeenLastCalledWith(['delete', '--yes', '--reassign=12', '1'])
+    })
+
+    it('should have the arguments to delete multiple users', () => {
+      user.delete([1, 12, 45])
+
+      expect(user.wpUser).toHaveBeenLastCalledWith(['delete', '--yes', 1, 12, 45])
+    })
+  })
+
+  describe('#get()', () => {
+    it('should have the arguments to get user data', () => {
+      user.wpUser = jest.fn((commands) => Promise.resolve({ stdout: JSON.stringify(commands) }))
+
+      user.get('user')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith([
+          'get',
+          '--format=json',
+          '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status',
+          'user',
+        ])
+    })
+  })
+
+  describe('#list()', () => {
+    it('should have the arguments to list users', () => {
+      user.wpUser = jest.fn((commands) => Promise.resolve({ stdout: JSON.stringify(commands) }))
+
+      user.list()
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith([
+          'list',
+          '--format=json',
+          '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status',
+        ])
+    })
+
+    it('should have the arguments to list users with filters', () => {
+      user.wpUser = jest.fn((commands) => Promise.resolve({ stdout: JSON.stringify(commands) }))
+
+      user.list({ ID: 1 })
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith([
+          'list',
+          '--format=json',
+          '--fields=ID,user_login,display_name,user_email,user_registered,roles,user_pass,user_nicename,user_url,user_activation_key,user_status',
+          '--ID=1',
+        ])
+    })
+
+    it('should throw error when filters is not object', () => {
+      user.wpUser = jest.fn((commands) => Promise.resolve({ stdout: JSON.stringify(commands) }))
+
+      expect(() => user.list('error')).toThrow(new TypeError('filters must be an object'))
+    })
+  })
+
+  describe('#listCaps()', () => {
+    it('should have the arguments to list user caps', () => {
+      user.wpUser = jest.fn((commands) => Promise.resolve({ stdout: JSON.stringify(commands) }))
+
+      user.listCaps('user')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['list-caps', '--format=json', 'user'])
+    })
+  })
+
+  describe('#removeCap()', () => {
+    it('should have the arguments to remove caps', () => {
+      user.removeCap('user', 'cap')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['remove-cap', 'user', 'cap'])
+    })
+  })
+
+  describe('#removeRole()', () => {
+    it('should have the arguments to remove role', () => {
+      user.removeRole('user', 'role')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['remove-role', 'user', 'role'])
+    })
+  })
+
+  describe('#setRole()', () => {
+    it('should have the arguments to set role', () => {
+      user.setRole('user', 'updated-role')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['set-role', 'user', 'updated-role'])
+    })
+  })
+
+  describe('#spam()', () => {
+    it('should have the arguments to set user as spam', () => {
+      user.spam('user')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['spam', 'user'])
+    })
+
+    it('should have the arguments to set user as spam with user id as parameter', () => {
+      user.spam(1)
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['spam', '1'])
+    })
+
+    it('should have the arguments to set multiple user as spam', () => {
+      user.spam(['user', 1])
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['spam', 'user', 1])
+    })
+  })
+
+  describe('#unspam()', () => {
+    it('should have the arguments to unspam user', () => {
+      user.unspam('user')
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['unspam', 'user'])
+    })
+
+    it('should have the arguments to unspam user with user id as parameter', () => {
+      user.unspam(1)
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['unspam', '1'])
+    })
+
+    it('should have the arguments to unspam multiple users', () => {
+      user.unspam(['user', 1])
+
+      expect(user.wpUser)
+        .toHaveBeenLastCalledWith(['unspam', 'user', 1])
+    })
+  })
+})

--- a/test/wp-cli/util.spec.js
+++ b/test/wp-cli/util.spec.js
@@ -1,4 +1,4 @@
-const { CheckIfArrayOrString } = require('../../src/wp-cli/util')
+const { CheckIfArrayOrString, FormatToWordpressDate } = require('../../src/wp-cli/util')
 
 describe('util', () => {
   describe('#CheckIfArrayOrString()', () => {
@@ -13,6 +13,20 @@ describe('util', () => {
 
     it('should throw an error with massage when item is not array or string', () => {
       expect(() => CheckIfArrayOrString(1, 'fail')).toThrow('fail must be an array or a string')
+    })
+  })
+
+  describe('#FormatToWordpressDate()', () => {
+    it('should return valid wordpress date with dates numbers smaller then 10', () => {
+      const date = new Date(2020, 5, 6, 2, 8, 3)
+
+      expect(FormatToWordpressDate(date)).toBe('2020-06-06-02-08-03')
+    })
+
+    it('should return valid wordpress date with dates numbers bigger then 10', () => {
+      const date = new Date(2020, 11, 20, 20, 40, 50)
+
+      expect(FormatToWordpressDate(date)).toBe('2020-12-20-20-40-50')
     })
   })
 })


### PR DESCRIPTION
# WHAT'S NEW
New WP cli for managing users and there traits. see #53 
## WP-CLI
Added the ability to manage user along with their roles, capabilities, and meta.
### UTIL
* Added method for converting Date object to WP cli date string
### USER API
* Added: add-cap - Adds a capability to a user.
* Added: add-role - Adds a role for a user.
* Added: create - Creates a new user.
* Added: delete - Deletes one or more users from the current site.
* Added: get - Get user data.
* Added: list - Return list of users in the WordPress site and there data.
* Added: list-caps -  Return the user's capabilities
* Added: remove-cap - Removes a user's capability.
* Added: remove-role - Removes a user's role.
* Added: set-role -  Sets the user role.
* Added: spam - Marks one or more users as spam.
* Added: unspam - Removes one or more users from spam.
* Added: update - Updates an existing user.
* Added: meta - Adds, updates, deletes, and lists user custom fields.
  * Added: add - Adds a meta field.
  * Added: delete - Deletes a meta field.
  * Added: get - Gets meta field value.
  * Added: list - Lists all metadata associated with a user.
  * Added: update - Updates a meta field.