### PR TITLE
optimize skip Words for git

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,21 +114,21 @@
         "warn",
         {
           "skipWords": [
-            "cywp",
-            "stdout",
-            "stderr",
-            "ps",
-            "Wordpress",
-            "Mysql",
-            "twentyseventeen",
-            "spwan",
-            "usr",
-            "cmd",
-            "wp",
-            "uri",
-            "php",
-            "nicename",
-            "unspam"
+            "cywp"
+            ,"stdout"
+            ,"stderr"
+            ,"ps"
+            ,"wordpress"
+            ,"mysql"
+            ,"twentyseventeen"
+            ,"spwan"
+            ,"usr"
+            ,"cmd"
+            ,"wp"
+            ,"uri"
+            ,"php"
+            ,"nicename"
+            ,"unspam"
           ]
         }
       ]


### PR DESCRIPTION
# WHA'S NEW
Change the way that the commas are arrange. this helps when multiple users want to add multiple words to skip from different branches  and to not date conflicts