### PR TITLE
fix: preperdocs.js not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "files": [
     "src/**",
-    "bin/cywp.js"
+    "bin/**"
   ],
   "directories": {
     "lib": "./src ",


### PR DESCRIPTION
# WHATS NEW
Fixed #145 